### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  BUILD_DOCKER_CONTAINER: false
+  # set this to true in GitHub variables to enable building the container
+  # HAS_CONTAINER: true
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  APPLICATION_NAME: gali-solver
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
   # just a name, but storing it separately as we're nice people
@@ -36,17 +36,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  produce-docker-container:
-    name: Should Docker container be built?
+  repo-has-container:
+    name: Repo has container?
     runs-on: ubuntu-latest
     outputs:
-      should: ${{ fromJSON(env.BUILD_DOCKER_CONTAINER) }}
+      has_container: ${{ steps.determine.outputs.has_container }}
 
     steps:
-      - name: Dummy
+      - name: Repo has docker container?
+        id: determine
         shell: bash
         run: |
-          echo "These are not the steps you're looking for..."
+          HAS_CONTAINER="${{ vars.HAS_CONTAINER }}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> ${GITHUB_OUTPUT}
 
   changes:
     name: Detect changes
@@ -69,12 +71,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - changes
-      - produce-docker-container
+      - repo-has-container
     outputs:
       version: ${{ steps.version.outputs.nextversion }}
     if: |
       github.event_name == 'pull_request' &&
-      fromJSON(needs.produce-docker-container.outputs.should) == true &&
+      fromJSON(needs.repo-has-container.outputs.has_container) == true &&
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
@@ -308,12 +310,11 @@ jobs:
         run: |
           grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
 
-      - name: Upload to CodeCov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@95b1a2355bd0e526ad2fd62da9fd386ad4c98474 # v2.2.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: reports
-          fail_ci_if_error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: reports/lcov.info
 
       - name: Fail if tests failed
         shell: bash
@@ -411,6 +412,12 @@ jobs:
         shell: bash
         run: |
           echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      - name: Set application name
+        shell: bash
+        run: |
+          APPLICATION_NAME=${{ github.repository }}
+          echo "APPLICATION_NAME=${APPLICATION_NAME##*/}" >> ${GITHUB_ENV}
 
       - name: Build Docker image
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -1,7 +1,8 @@
 name: Retag containers after new push / PR
 
 env:
-  BUILD_DOCKER_CONTAINER: false
+  # set this to true in GitHub variables to enable building the container
+  # HAS_CONTAINER: true
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
@@ -31,25 +32,27 @@ permissions:
   packages: write
 
 jobs:
-  produce-docker-container:
-    name: Should Docker container be built?
+  repo-has-container:
+    name: Repo has container?
     runs-on: ubuntu-latest
     outputs:
-      should: ${{ fromJSON(env.BUILD_DOCKER_CONTAINER) }}
+      has_container: ${{ steps.determine.outputs.has_container }}
 
     steps:
-      - name: Dummy
+      - name: Repo has docker container?
+        id: determine
         shell: bash
         run: |
-          echo "These are not the steps you're looking for..."
+          HAS_CONTAINER="${{ vars.HAS_CONTAINER }}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> ${GITHUB_OUTPUT}
 
   retag-containers:
     name: Retag the containers
     runs-on: ubuntu-latest
     needs:
-      - produce-docker-container
+      - repo-has-container
     if: |
-      fromJSON(needs.produce-docker-container.outputs.should) == true
+      fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/semantic-tags-after-release.yml
+++ b/.github/workflows/semantic-tags-after-release.yml
@@ -163,13 +163,11 @@ jobs:
       - name: Set full image name
         shell: bash
         run: |
-
           echo "FULL_IMAGE_NAME=${REGISTRY,,}/${IMAGE_NAME,,}" >> ${GITHUB_ENV}
 
       - name: Find all tags for ${{ env.FULL_IMAGE_NAME }}
         shell: bash
         run: |
-
           crane ls ${FULL_IMAGE_NAME} >> existing_tags
 
           echo "These are the existing tags on ${FULL_IMAGE_NAME}:"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,8 +18,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "gali_solver=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,gali_solver=trace"
             }
         },
         {
@@ -41,8 +41,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "gali_solver=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,gali_solver=trace"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "type": "cargo",
             "command": "build",
-            "args": [],
+            "args": ["--workspace", "--all-targets", "--all-features"],
             "problemMatcher": ["$rustc"],
             "group": "build",
             "label": "Rust: cargo build"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,18 +101,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.16"
+version = "4.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bb1b4028935821b2d6b439bba2e970bdcf740832732437ead910c632e30d7d"
+checksum = "5b0827b011f6f8ab38590295339817b0d26f344aa4932c3ced71b45b0c54b4a9"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.16"
+version = "4.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae467cbb0111869b765e13882a1dbbd6cb52f58203d8b80c44f667d4dd19843"
+checksum = "9441b403be87be858db6a23edb493e7f694761acdc3343d5a0fcaafd304cbc9e"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,5 @@ USER appuser
 WORKDIR /app
 COPY --from=builder /output/bin/${APPLICATION_NAME} /app/entrypoint
 
+ENV RUST_BACKTRACE=full
 ENTRYPOINT ["/app/entrypoint"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,8 @@ fn parse_cli() -> Result<(u32, Vec<u32>), color_eyre::Report> {
 }
 
 fn main() -> Result<(), color_eyre::Report> {
+    color_eyre::install()?;
+
     let (expected, v) = parse_cli()?;
 
     let permutations = build_permutations_r(&v)

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+NEW_NAME=$1
+
+FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
+
+
+echo "New name = ${NEW_NAME}"
+
+
+if [[ ${#FILTERED_NAME} != 0 ]]; then
+    echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
+    exit 1
+fi
+
+
+NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
+
+echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
+
+
+P1="rust-end-to-end-"
+OLD_NAME="${P1}application"
+OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
+
+echo ${OLD_NAME_WITH_UNDERSCORE}
+
+
+rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE} | xargs -i sed -i "s/${OLD_NAME_WITH_UNDERSCORE}/${NEW_NAME_WITH_UNDERSCORE}/g" {}


### PR DESCRIPTION
- chore(deps): update semantic-release monorepo
- chore(deps): update dependency conventional-changelog-conventionalcommits to v6
- fix: set maximum backtrace
- chore(deps): update docker/build-push-action action to v4.1.0
- chore(deps): update actions/checkout action to v3.5.3
- chore(deps): update returntocorp/semgrep docker tag to v1.26.0
- chore(deps): update rust:1.70.0 docker digest to 508253a
- chore(deps): update docker/build-push-action action to v4.1.1
- chore(deps): update dependency semantic-release to ^21.0.5
- chore(deps): update docker/metadata-action action to v4.6.0
- chore(deps): update alpine docker tag to v3.18.2
- chore(deps): update returntocorp/semgrep docker tag to v1.27.0
- chore(deps): update docker/setup-buildx-action action to v2.7.0
- chore(deps): update github/codeql-action action to v2.20.0
- chore(deps): update alpine:3.18.2 docker digest to c7431a7
- chore(deps): update alpine:3.18.2 docker digest to 5246eec
- chore(deps): update alpine:3.18.2 docker digest to 82d1e9d
- chore(deps): update mcr.microsoft.com/devcontainers/rust docker tag to v1
- chore(deps): update dependency semver to ^7.5.2
- fix: also do RUST_BACKTRACE=full for debugging
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^6.1.0
- chore(deps): lock file maintenance
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.8.0
- chore(deps): update node.js to >=v18.16.1
- chore(deps): update returntocorp/semgrep docker tag to v1.28.0
- chore(deps): update github/codeql-action action to v2.20.1
- chore(deps): update npm to >=9.7.2
- chore(deps): update dependency semver to ^7.5.3
- fix: build all with tests too
- fix: trace for all, not just the app
- fix: default is to use color-eyre
- fix: trace for run and test
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.29.0
- chore(deps): update docker/setup-buildx-action action to v2.8.0
- chore(deps): update returntocorp/semgrep docker tag to v1.30.0
- chore(deps): update dependency semantic-release to ^21.0.6
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.20.2
- chore(deps): update rust:1.70.0 docker digest to d3283ba
- chore(deps): update rust:1.70.0 docker digest to a8d4f44
- chore(deps): update rust:1.70.0 docker digest to 28ee882
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.4
- chore(deps): update dependency semantic-release to ^21.0.7
- chore(deps): update rust:1.70.0 docker digest to dbdf889
- chore(deps): update actions/setup-node action to v3.7.0
- chore(deps): update npm to >=9.8.0
- chore(deps): update github/codeql-action action to v2.20.3
- chore(deps): update dependency prettier to v3
- fix: add update-name script
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to b732d41
- chore(deps): update docker/setup-buildx-action action to v2.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.31.1
- chore(deps): update dependency semver to ^7.5.4
- chore(deps): update returntocorp/semgrep docker tag to v1.31.2
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v2.9.1
- fix: Coveralls as CodeCov keeps on failing
- fix: specify version, Renovate will pin it
- chore(deps): update github/codeql-action action to v2.20.4
- chore(deps): pin coverallsapp/github-action action to 95b1a23
- chore(deps): update rust to v1.71.0
- chore(deps): update returntocorp/semgrep docker tag to v1.32.0
- chore(deps): lock file maintenance
- fix: make BUILD_DOCKER_CONTAINER configurable from variables
- fix: env -> vars
- fix: get application name automatically
- fix: remove unneeded newline
- chore(deps): update dependency @semantic-release/github to ^9.0.4
- chore(deps): lock file maintenance
- chore(deps): update node.js to >=v18.17.0
- chore(deps): update github/codeql-action action to v2.21.0
- chore(deps): update npm to >=9.8.1
- chore(deps): update returntocorp/semgrep docker tag to v1.33.0
